### PR TITLE
Save mask in uint8

### DIFF
--- a/mirror_symmetry/mirror_symmetry_tools.py
+++ b/mirror_symmetry/mirror_symmetry_tools.py
@@ -20,7 +20,7 @@ def main(img_path, save_path=None, flip_direction=0, create_mask=None,
         save_path = os.getcwd()
 
     if create_mask:
-        save_nii(symmetry_mask.astype(int), img_affine,
+        save_nii(symmetry_mask.astype(np.int8), img_affine,
                  os.path.join(save_path, 'symmetry_mask'))
     if mirror_image:
         save_nii(mirror_images[0], img_affine, os.path.join(save_path,

--- a/mirror_symmetry/mirror_symmetry_tools.py
+++ b/mirror_symmetry/mirror_symmetry_tools.py
@@ -20,7 +20,7 @@ def main(img_path, save_path=None, flip_direction=0, create_mask=None,
         save_path = os.getcwd()
 
     if create_mask:
-        save_nii(symmetry_mask.astype(np.int8), img_affine,
+        save_nii(symmetry_mask.astype(np.uint8), img_affine,
                  os.path.join(save_path, 'symmetry_mask'))
     if mirror_image:
         save_nii(mirror_images[0], img_affine, os.path.join(save_path,


### PR DESCRIPTION
`int` is `np.int64`, which makes Slicer crash as reported [here](https://issues.slicer.org/view.php?id=4665).